### PR TITLE
fix(warning): deprecated keyword_separation

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -26,6 +26,7 @@ dependencies:
         tar -xjpf "ffmpeg-$FFMPEG_VERSION.tar.bz2" &&
         cd "ffmpeg-$FFMPEG_VERSION" &&
         ./configure
+	--disable-yasm
         --extra-cflags="-I$FFMPEG_DIR/fdkaac/include"
         --extra-ldflags="-L$FFMPEG_DIR/fdkaac/lib"
         --enable-gpl

--- a/circle.yml
+++ b/circle.yml
@@ -26,7 +26,7 @@ dependencies:
         tar -xjpf "ffmpeg-$FFMPEG_VERSION.tar.bz2" &&
         cd "ffmpeg-$FFMPEG_VERSION" &&
         ./configure
-	--disable-yasm
+        --disable-yasm
         --extra-cflags="-I$FFMPEG_DIR/fdkaac/include"
         --extra-ldflags="-L$FFMPEG_DIR/fdkaac/lib"
         --enable-gpl

--- a/lib/mediakit/ffmpeg/options.rb
+++ b/lib/mediakit/ffmpeg/options.rb
@@ -62,7 +62,7 @@ module Mediakit
       end
 
       # Base class for Options
-      class OrderedHash < ActiveSupport::OrderedHash
+      class OrderedHash < Hash
         # @param [Hash] options initial option values
         def initialize(options = {})
           options.each { |key, value| raise_if_invalid_arg_error(key, value) } if options

--- a/lib/mediakit/process/runner.rb
+++ b/lib/mediakit/process/runner.rb
@@ -96,9 +96,9 @@ module Mediakit
       end
 
       def teardown_watchers
-        @loop.watchers.each { |w| w.detach  if w.attached? }
+        @loop.watchers.each { |w| w.detach if w.attached? }
         @loop.stop if @loop.has_active_watchers?
-      rescue RuntimeError => e
+      rescue RuntimeError, TypeError => e
         logger.warn(e.message)
         logger.warn(e.backtrace.join("\n"))
       end

--- a/mediakit.gemspec
+++ b/mediakit.gemspec
@@ -23,7 +23,7 @@ EOS
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activesupport", "~> 4"
-  spec.add_runtime_dependency "cool.io", "~> 1.3"
+  spec.add_runtime_dependency "cool.io", "~> 1.5.3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "pry", '~> 0.10'
   spec.add_development_dependency "ruby-debug-ide", "~> 0.4"

--- a/mediakit.gemspec
+++ b/mediakit.gemspec
@@ -22,9 +22,7 @@ EOS
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", "~> 4"
   spec.add_runtime_dependency "cool.io", "~> 1.5.3"
-  spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "pry", '~> 0.10'
   spec.add_development_dependency "ruby-debug-ide", "~> 0.4"
   spec.add_development_dependency "yard", "> 0.8"


### PR DESCRIPTION
* Fixed deprecation warnings in ruby 2.7.
* These are obsolete in ruby3.
* https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

```log
lib/mediakit/drivers.rb:36: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
lib/mediakit/process/runner.rb:20: warning: The called method `initialize' is defined here
```